### PR TITLE
Deck shuffle SecureRandom object instantiation

### DIFF
--- a/src/main/java/io/lyuda/jcards/Deck.java
+++ b/src/main/java/io/lyuda/jcards/Deck.java
@@ -25,6 +25,8 @@ public class Deck implements Comparable<Deck> {
      */
     private final List<Card> cards;
 
+    private static final SecureRandom secureRandom = new SecureRandom();
+
     /**
      * Creates a new deck of cards with all the possible combinations of suits and ranks.
      */
@@ -44,7 +46,6 @@ public class Deck implements Comparable<Deck> {
      * @see java.security.SecureRandom
      */
     public void shuffle() {
-        SecureRandom secureRandom = new SecureRandom();
         long seed = secureRandom.nextLong();
         Collections.shuffle(cards, new Random(seed));
     }


### PR DESCRIPTION
Unlike the `java.util.Random` class, the `SecureRandom` is guaranteed not to generate the same result. Because of this, you only really need one instance of this class. Instantiating a new object with each method call is costly.