### PR TITLE
Publish Maven package to GitHub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: 'Publish package'
+
+on:
+    push:
+        tags:
+            - '**'
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: 'Checkout'
+              uses: actions/checkout@v3
+
+            - name: 'Set up JDK 17'
+              uses: actions/setup-java@v3
+              with:
+                  java-version: '17'
+                  distribution: 'adopt'
+
+            - name: 'Build and Test'
+              run: mvn verify
+
+            - name: 'Publish package'
+              run: mvn -Dmaven.test.skip=true deploy
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,6 @@
 >
     <modelVersion>4.0.0</modelVersion>
 
-    <distributionManagement>
-
-    </distributionManagement>
     <groupId>io.lyuda</groupId>
     <artifactId>jcards</artifactId>
     <version>0.0.5</version>
@@ -37,11 +34,25 @@
         </developer>
     </developers>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/lyudaio/jcards</url>
+        </repository>
+    </distributionManagement>
+
+    <properties>
+        <java.version>17</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.9.2</junit.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.2</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -51,7 +62,7 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
-                <version>5.9.2</version>
+                <version>${junit.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This PR contains a script to publish this library to GitHub registry. 
This is really useful, in contrary to downloading a JAR file and importing it to the project.

The script is setup as such that it will publish a new package on each new tag. So when you tag a new version, that version will be published.

I'm not 100% sure that it will work 'as is' right now, as I cannot really test it fully. If it fails to work, you might need to make some adjustments according to the docs.

For more info, check out:
- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags
- https://github.com/marketplace/actions/setup-java-jdk